### PR TITLE
Improve Lido Oracle rewards handling

### DIFF
--- a/src/agent-beth-rewards.ts
+++ b/src/agent-beth-rewards.ts
@@ -65,8 +65,12 @@ export async function initialize(currentBlock: number) {
 
   rewardsLiquidatorAddress = await anchorVault.rewards_liquidator()
 
-  console.log('[AgentBethRewards] lastRewardsSell:', lastRewardsSell)
-  console.log('[AgentBethRewards] rewardsLiquidatorAddress:', rewardsLiquidatorAddress)
+  console.log(`[AgentBethRewards] lastRewardsSell: {
+    timestamp: ${lastRewardsSell.timestamp},
+    stethAmount: ${formatEth(lastRewardsSell.stethAmount, 5)},
+    ustAmount: ${formatEth(lastRewardsSell.ustAmount, 3)}\n}`)
+
+  console.log(`[AgentBethRewards] rewardsLiquidatorAddress: ${rewardsLiquidatorAddress}`)
 }
 
 
@@ -76,7 +80,7 @@ export async function handleBlock(blockEvent: BlockEvent) {
   await agentLidoOracle.waitBlockHandled(blockEvent.blockHash)
   const lastOracleReport = await agentLidoOracle.getLastOracleReport()
 
-  if (lastRewardsSell.timestamp > lastOracleReport.timestamp) {
+  if (lastOracleReport == null || lastRewardsSell.timestamp > lastOracleReport.timestamp) {
     // rewards already sold
     return findings
   }

--- a/src/agent-beth-rewards.ts
+++ b/src/agent-beth-rewards.ts
@@ -165,7 +165,7 @@ function handleAnchorVaultTx(txEvent: TransactionEvent, findings: Finding[]) {
   findings.push(Finding.fromObject({
     name: 'Anchor rewards collected',
     description: `Sold ${stethDispAmount} stETH to ${ustDispAmount} UST, ` +
-      `feed price ${stethUstDispPrice} UST per ETH, slippage ${slippageDispPercent}%`,
+      `feed price ${stethUstDispPrice} UST per stETH, slippage ${slippageDispPercent}%`,
     alertId: 'BETH-REWARDS-COLLECTED',
     severity: FindingSeverity.Info,
     type: FindingType.Info,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -9,7 +9,17 @@ export function formatEth(amount: any, dp: number): string {
 }
 
 
-export function formatDelay(delaySec: number) {
-  const delayMin = Math.floor(delaySec / 60)
-  return `${delayMin} min ${delaySec - delayMin * 60} sec`
+export function formatDelay(fullDelaySec: number) {
+  let sign = fullDelaySec >= 0 ? 1 : -1
+  let delayHours = 0
+  let delayMin = Math.floor(sign * fullDelaySec / 60)
+  let delaySec = sign * fullDelaySec - delayMin * 60
+  if (delayMin >= 60) {
+    delayHours = Math.floor(delayMin / 60)
+    delayMin -= delayHours * 60
+  }
+  return (sign == 1 ? '' : '-') +
+    (delayHours > 0 ? `${delayHours} hrs ` : '') +
+    (delayMin > 0 ? `${delayMin} min ` : '') +
+    `${delaySec} sec`
 }


### PR DESCRIPTION
Previously, rewards were checked for being decreased only starting from the second report after the agent start. This PR adds the support for doing this for the first oracle report after the start.

This is done by fetching two last historic reports upon agent start (instead of just the last one) and calculating the rewards amount for the last report to be able to compare it to the future rewards amount.