### PR TITLE
Refactor Depositor alerts

### DIFF
--- a/src/agent-dao-ops.ts
+++ b/src/agent-dao-ops.ts
@@ -122,7 +122,7 @@ async function handleBufferedEth(blockEvent: BlockEvent, findings: Finding[]) {
         Finding.fromObject({
           name: "Huge buffered ETH amount",
           description: `There are ${bufferedEth.toFixed(4)} buffered ETH in DAO for more than ${Math.floor(MAX_BUFFERED_ETH_AMOUNT_CRITICAL_TIME / ( 60 * 60 ))} hour(s)`,
-          alertId: "HUGE_BUFFERED_ETH",
+          alertId: "HUGE-BUFFERED-ETH",
           severity: FindingSeverity.High,
           type: FindingType.Degraded,
         })
@@ -133,7 +133,7 @@ async function handleBufferedEth(blockEvent: BlockEvent, findings: Finding[]) {
         Finding.fromObject({
           name: "High buffered ETH amount",
           description: `There are ${bufferedEth.toFixed(4)} buffered ETH in DAO and there are more than ${Math.floor(MAX_DEPOSITOR_TX_DELAY / ( 60 * 60 ))} hours since last Depositor TX`,
-          alertId: "HIGH_BUFFERED_ETH",
+          alertId: "HIGH-BUFFERED-ETH",
           severity: FindingSeverity.Medium,
           type: FindingType.Suspicious,
         })

--- a/src/agent-dao-ops.ts
+++ b/src/agent-dao-ops.ts
@@ -18,26 +18,28 @@ import {
   NODE_OPERATORS_REGISTRY_ADDRESS,
   LIDO_DAO_ADDRESS,
   MIN_AVAILABLE_KEYS_COUNT,
-  MAX_BUFFERED_ETH_AMOUNT,
+  MAX_BUFFERED_ETH_AMOUNT_CRITICAL,
+  MAX_BUFFERED_ETH_AMOUNT_MEDIUM,
   ETH_DECIMALS,
   LIDO_DEPOSIT_SECURITY_ADDRESS,
+  MAX_DEPOSITOR_TX_DELAY,
+  MAX_BUFFERED_ETH_AMOUNT_CRITICAL_TIME,
 } from "./constants";
 
 export const name = "DaoOps";
 
 const REPORT_WINDOW = 60 * 60 * 24;
-// 12 hours
-const MAX_DEPOSITOR_TX_DELAY = 60 * 60 * 12;
 let lastReportedKeysShortage = 0;
 let lastReportedBufferedEth = 0;
 let lastDepositorTxTime = 0;
+let criticalBufferAmountFrom = 0;
 
 export async function initialize(
   currentBlock: number
 ): Promise<{ [key: string]: string }> {
   console.log(`[${name}]`);
   let provider = new ethers.providers.EtherscanProvider();
-  let history = await provider.getHistory(LIDO_DEPOSIT_SECURITY_ADDRESS, currentBlock - Math.floor(60 * 60 * 24 / 13));
+  let history = await provider.getHistory(LIDO_DEPOSIT_SECURITY_ADDRESS, currentBlock - Math.floor(60 * 60 * 24 / 13), currentBlock - 1);
   const depositorTxTimestamps = history.map(x => x.timestamp ? x.timestamp : 0);
   if (depositorTxTimestamps.length > 0) {
     depositorTxTimestamps.sort((a,b) => a - b)
@@ -97,24 +99,43 @@ async function handleNodeOperatorsKeys(
 
 async function handleBufferedEth(blockEvent: BlockEvent, findings: Finding[]) {
   const now = blockEvent.block.timestamp;
+  const lidoDao = new ethers.Contract(
+    LIDO_DAO_ADDRESS,
+    LIDO_DAO_ABI,
+    ethersProvider
+  );
+  const bufferedEthRaw = new BigNumber(
+    String(await lidoDao.functions.getBufferedEther({blockTag:blockEvent.block.number}))
+  );
+  const bufferedEth = bufferedEthRaw.div(ETH_DECIMALS).toNumber();
+  // Keep track of buffer size above MAX_BUFFERED_ETH_AMOUNT_CRITICAL
+  if (bufferedEth > MAX_BUFFERED_ETH_AMOUNT_CRITICAL) {
+    criticalBufferAmountFrom = criticalBufferAmountFrom != 0 ? criticalBufferAmountFrom : now
+  } else {
+    // reset counter if buffered amount goes below MAX_BUFFERED_ETH_AMOUNT_CRITICAL
+    criticalBufferAmountFrom = 0;
+  }
+  console.log(criticalBufferAmountFrom)
   if (lastReportedBufferedEth + REPORT_WINDOW < now) {
-    const lidoDao = new ethers.Contract(
-      LIDO_DAO_ADDRESS,
-      LIDO_DAO_ABI,
-      ethersProvider
-    );
-    const bufferedEthRaw = new BigNumber(
-      String(await lidoDao.functions.getBufferedEther())
-    );
-    const bufferedEth = bufferedEthRaw.div(ETH_DECIMALS).toNumber();
-    if (bufferedEth > MAX_BUFFERED_ETH_AMOUNT && lastDepositorTxTime < now - MAX_DEPOSITOR_TX_DELAY) {
+    if (bufferedEth > MAX_BUFFERED_ETH_AMOUNT_CRITICAL && criticalBufferAmountFrom < now - MAX_BUFFERED_ETH_AMOUNT_CRITICAL_TIME) {
+      findings.push(
+        Finding.fromObject({
+          name: "Huge buffered ETH amount",
+          description: `There are ${bufferedEth.toFixed(4)} buffered ETH in DAO for more than ${Math.floor(MAX_BUFFERED_ETH_AMOUNT_CRITICAL_TIME / ( 60 * 60 ))} hour(s)`,
+          alertId: "HUGE_BUFFERED_ETH",
+          severity: FindingSeverity.High,
+          type: FindingType.Degraded,
+        })
+      );
+      lastReportedBufferedEth = now
+    } else if (bufferedEth > MAX_BUFFERED_ETH_AMOUNT_MEDIUM && lastDepositorTxTime < now - MAX_DEPOSITOR_TX_DELAY) {
       findings.push(
         Finding.fromObject({
           name: "High buffered ETH amount",
-          description: `There are ${bufferedEth.toFixed(4)} buffered ETH in DAO and there are more than 12 hours since last Depositor TX`,
+          description: `There are ${bufferedEth.toFixed(4)} buffered ETH in DAO and there are more than ${Math.floor(MAX_DEPOSITOR_TX_DELAY / ( 60 * 60 ))} hours since last Depositor TX`,
           alertId: "HIGH_BUFFERED_ETH",
           severity: FindingSeverity.Medium,
-          type: FindingType.Info,
+          type: FindingType.Suspicious,
         })
       );
       lastReportedBufferedEth = now

--- a/src/agent-dao-ops.ts
+++ b/src/agent-dao-ops.ts
@@ -115,7 +115,6 @@ async function handleBufferedEth(blockEvent: BlockEvent, findings: Finding[]) {
     // reset counter if buffered amount goes below MAX_BUFFERED_ETH_AMOUNT_CRITICAL
     criticalBufferAmountFrom = 0;
   }
-  console.log(criticalBufferAmountFrom)
   if (lastReportedBufferedEth + REPORT_WINDOW < now) {
     if (bufferedEth > MAX_BUFFERED_ETH_AMOUNT_CRITICAL && criticalBufferAmountFrom < now - MAX_BUFFERED_ETH_AMOUNT_CRITICAL_TIME) {
       findings.push(

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -211,7 +211,17 @@ export const POOL_REWARDS_ALERTS_PERIODS_PARAMS = [
 
 export const MIN_AVAILABLE_KEYS_COUNT = 1000
 
-export const MAX_BUFFERED_ETH_AMOUNT = 2000
+// 5000 ETH
+export const MAX_BUFFERED_ETH_AMOUNT_CRITICAL = 5000
+
+// 2000 ETH
+export const MAX_BUFFERED_ETH_AMOUNT_MEDIUM = 2000
+
+// 72 hours
+export const MAX_DEPOSITOR_TX_DELAY = 60 * 60 * 72
+
+// 1 hour
+export const MAX_BUFFERED_ETH_AMOUNT_CRITICAL_TIME = 60 * 60
 
 export const ETH_DECIMALS = new BigNumber(10).pow(18)
 


### PR DESCRIPTION
Current depositor alerts:
- HUGE-BUFFERED-ETH triggered when there are more than MAX_BUFFERED_ETH_AMOUNT_CRITICAL (5000 ETH atm) for 1 hour or more
- HIGH-BUFFERED-ETH triggered when there are more than MAX_BUFFERED_ETH_AMOUNT_MEDIUM (2000 ETH atm) and no TX from depositor for 72 hours
Both alerts have a common SP of 24 hours
Both alerts are markers for Depositor Bot issues