### PR TITLE
fix: Handle multiple events in single TX (lido-rewards)

### DIFF
--- a/lido-rewards/src/agent-reward-programs.ts
+++ b/lido-rewards/src/agent-reward-programs.ts
@@ -190,8 +190,7 @@ async function handleEasyTrackTransaction(
       MOTION_CREATED_EVENT,
       EASY_TRACK_ADDRESS
     );
-    for (let i = 0; i < eventsCreated.length; i++) {
-      let eventCreated = eventsCreated[i];
+    for (const eventCreated of eventsCreated) {
       const id = parseInt(String(eventCreated.args._motionId));
       if (
         eventCreated.args._evmScriptFactory.toLowerCase() ==
@@ -243,8 +242,7 @@ async function handleEasyTrackTransaction(
       MOTION_ENACTED_EVENT,
       EASY_TRACK_ADDRESS
     );
-    for (let i = 0; i < eventsEnacted.length; i++) {
-      let eventEnacted = eventsEnacted[i];
+    for (const eventEnacted of eventsEnacted) {
       const id = parseInt(String(eventEnacted.args._motionId));
       const amount = pendingTopUpMotions.get(id);
       pendingTopUpMotions.delete(id);


### PR DESCRIPTION
Tested on https://etherscan.io/tx/0x93d2c9afe341295e0254ff887c19b159078d8a69837762b990e6b37e110d4af1