### PR TITLE
Fix mocked runs

### DIFF
--- a/lido-on-polygon/e2e/agent-dao-ops.e2e-spec.ts
+++ b/lido-on-polygon/e2e/agent-dao-ops.e2e-spec.ts
@@ -1,8 +1,12 @@
 import { configureContainer, Finding } from "forta-agent";
 import { AwilixContainer, asFunction } from "awilix";
-import { provideAgentPath } from "./utils";
+import {
+  provideAgentPath,
+  provideRunBlock,
+  provideRunTransaction,
+} from "./utils";
 
-const BLOCK_PROCESSING_TIMEOUT = 60_000; // ms
+const TEST_TIMEOUT = 60_000; // ms
 
 describe("agent-dao-ops e2e tests", () => {
   let runBlock: (blockHashOrNumber: string | number) => Promise<Finding[]>;
@@ -18,52 +22,67 @@ describe("agent-dao-ops e2e tests", () => {
     const container = configureContainer() as AwilixContainer;
     container.register({
       agentPath: asFunction(provideAgentPath("agent-dao-ops")),
+      runTransaction: asFunction(provideRunTransaction),
+      runBlock: asFunction(provideRunBlock),
     });
 
     // https://docs.forta.network/en/latest/cli/#invoke-commands-programmatically
-    runTransaction = container.resolve("runHandlersOnTransaction");
-    runBlock = container.resolve("runHandlersOnBlock");
+    runTransaction = container.resolve("runTransaction");
+    runBlock = container.resolve("runBlock");
   });
 
   afterAll(() => {
     jest.resetAllMocks();
   });
 
-  it("should process tx with rewards distribution", async () => {
-    const findings = await runTransaction(
-      "0x19b1c8bdaab9cb2dd9fc89ca9ee916cd050ce8552394479a21a6fbac7271dbb4"
-    );
-    expect(findings.at(0)).toMatchSnapshot();
-  });
+  it(
+    "should process tx with rewards distribution",
+    async () => {
+      const findings = await runTransaction(
+        "0x19b1c8bdaab9cb2dd9fc89ca9ee916cd050ce8552394479a21a6fbac7271dbb4"
+      );
+      expect(findings.at(0)).toMatchSnapshot();
+    },
+    TEST_TIMEOUT
+  );
 
-  it("should process tx with polygon checkpoint reward change", async () => {
-    const findings = await runTransaction(
-      "0xfe9ef91c9b05aac2cdad146e90dd8145f8664408c0343504d5dc64077bf9d223"
-    );
-    expect(findings.at(0)).toMatchSnapshot();
-  });
+  it(
+    "should process tx with polygon checkpoint reward change",
+    async () => {
+      const findings = await runTransaction(
+        "0xfe9ef91c9b05aac2cdad146e90dd8145f8664408c0343504d5dc64077bf9d223"
+      );
+      expect(findings.at(0)).toMatchSnapshot();
+    },
+    TEST_TIMEOUT
+  );
 
-  it("should process tx with pooled MATIC delegation", async () => {
-    const findings = await runTransaction(
-      "0xe4577288b59eb8f834287151d63b0bd9a76e5ec6e177e9930b35d8dc4bf8daad"
-    );
-    expect(findings.at(0)).toMatchSnapshot();
-  });
+  it(
+    "should process tx with pooled MATIC delegation",
+    async () => {
+      const findings = await runTransaction(
+        "0xe4577288b59eb8f834287151d63b0bd9a76e5ec6e177e9930b35d8dc4bf8daad"
+      );
+      expect(findings.at(0)).toMatchSnapshot();
+    },
+    TEST_TIMEOUT
+  );
 
   it(
     "should process block with low deposit executor balance",
     async () => {
       const findings = await runBlock(16011700);
-      expect(findings.at(1)).toMatchSnapshot();
+      expect(findings.at(0)).toMatchSnapshot();
     },
-    BLOCK_PROCESSING_TIMEOUT
+    TEST_TIMEOUT
   );
+
   it(
     "should alert on low deposit executor balance only for 100th blocks",
     async () => {
       const findings = await runBlock(16011701);
       expect(findings.length).toEqual(0);
     },
-    BLOCK_PROCESSING_TIMEOUT
+    TEST_TIMEOUT
   );
 });

--- a/lido-on-polygon/e2e/utils.ts
+++ b/lido-on-polygon/e2e/utils.ts
@@ -1,6 +1,10 @@
 import fs from "fs";
 import { join } from "path";
 import { jsonc } from "jsonc";
+import { Provider } from "@ethersproject/abstract-provider";
+
+import { RunHandlersOnBlock } from "forta-agent/dist/cli/utils/run.handlers.on.block";
+import { RunHandlersOnTransaction } from "forta-agent/dist/cli/utils/run.handlers.on.transaction";
 
 /**
  * Helper function to use the given module as agent path.
@@ -17,4 +21,63 @@ export function provideAgentPath(
 
     return join(contextPath, compilerOptions.outDir, moduleName);
   };
+}
+
+/**
+ * Replacement for runHandlersOnTransaction for e2e tests container. Duplicates
+ * logic from agent.ts to be able to initialize sub-agents in the same manner
+ * as the main one.
+ */
+export function provideRunTransaction(
+  runHandlersOnTransaction: RunHandlersOnTransaction,
+  ethersProvider: Provider,
+  dynamicImport: any,
+  agentPath: string
+) {
+  return async function (txHash: string) {
+    const agent = await dynamicImport(agentPath);
+    if (typeof agent.initialize === "function") {
+      const tx = await ethersProvider.getTransaction(txHash);
+      if (!tx?.blockNumber) {
+        throw new Error(
+          `Error retrieving block number of transaction ${txHash}`
+        );
+      }
+      await agent.initialize(tx.blockNumber);
+    }
+
+    return await runHandlersOnTransaction(txHash);
+  };
+}
+
+/**
+ * Replacement for runHandlersOnBlock for e2e tests container. Duplicates logic
+ * from agent.ts to be able to initialize sub-agents in the same manner as the
+ * main one.
+ */
+export function provideRunBlock(
+  runHandlersOnBlock: RunHandlersOnBlock,
+  dynamicImport: any,
+  agentPath: string
+) {
+  return async function (blockHashOrNumber: string | number) {
+    const agent = await dynamicImport(agentPath);
+    if (typeof agent.initialize === "function") {
+      await agent.initialize(blockHashOrNumber);
+    }
+
+    return await runHandlersOnBlock(blockHashOrNumber);
+  };
+}
+
+/**
+ * Logging function for local runs that works over the process stderr
+ * directly instead of `console.log` calls.
+ */
+export function log(obj: any): void {
+  if ("GITHUB_ACTION" in process.env) {
+    return;
+  }
+
+  process.stderr.write(JSON.stringify(obj, null, 4));
 }

--- a/lido-on-polygon/src/agent.ts
+++ b/lido-on-polygon/src/agent.ts
@@ -63,8 +63,7 @@ const initialize = async () => {
     if (!tx.blockNumber) {
       throw new Error(`Transaction ${argv[4]} was not yet included into block`);
     }
-    blockNumber =
-      (await ethersProvider.getTransaction(argv[4])).blockNumber || -1;
+    blockNumber = tx.blockNumber;
   }
 
   if (blockNumber == -1) {


### PR DESCRIPTION
The common scheme for the CLI run is as follows:

- `runBlock`  
	- uses `runHandlersOnBlock`  
	- `runHandlersOnBlock`  
		- uses `getAgentHandlers` to get `handleBlock` && `handleTransaction`  
		- `getAgentHandlers`  
			- runs `initialize`, where `shouldRunInitialize` is always `True`  

The only difference between the standalone run and the tests' run is invoking a specific **sub** agent whose `initialize` function does not provide the expected API and should be adapted to be able to use in E2E tests as well.