### PR TITLE
chore: add maverick-swap-alpha contract to WL

### DIFF
--- a/phishing-detect/src/constants.ts
+++ b/phishing-detect/src/constants.ts
@@ -158,6 +158,7 @@ const WHITE_LIST_ADDRESSES_RAW: string[] = [
   "0x9409280dc1e6d33ab7a8c6ec03e5763fb61772b5", // Curve pool LDOETH-f
   "0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2", // AAVE v3
   "0xb748952c7bc638f31775245964707bcc5ddfabfc", // AAVE v3 Migration Helper
+  "0xd98e1c56a56a0ec5ca4bf6fdfbfa1572ee4d8a8d", // maverick-swap-alpha
 ];
 
 export const WHITE_LIST_ADDRESSES: string[] = WHITE_LIST_ADDRESSES_RAW.map(


### PR DESCRIPTION
Looks like AMM, possibly related to https://www.mav.xyz.
Deployed by the curator of https://thegraph.com/explorer/subgraphs/8CLKufQbE8tCFFn9NtHanTFiKnSKoTTggaNMJyKitEMx.
Contract internally calls NFT token, which is marked as [Maverick Position NFT (MPN)](https://etherscan.io/token/0x47c55b0d7967341435f7d1be0e643cab71fc5229).
Transactions to the contract look legit:
![0x8cb02fb1bca1ff4a11d26b66f7f6b1e2e74c78a9439bd4396343602dc6640ea4](https://user-images.githubusercontent.com/10616301/216962885-ee352702-92e0-454c-a2ea-3965e9a12fa9.png)
⚠️ Project itself is in alpha and does not provide public mainnet UI.