### PR TITLE
chore: add maveric pools wrapper

### DIFF
--- a/phishing-detect/src/constants.ts
+++ b/phishing-detect/src/constants.ts
@@ -166,6 +166,7 @@ const WHITE_LIST_ADDRESSES_RAW: string[] = [
   "0x13c7bcc2126d6892eefd489ad215a1a09f36aa9f", // Mellow ERC20RootVault
   "0xbfafc964361f78754f523343b09b3cb7bb73bdd6", // Mellow Tamper Strategy
   "0x7f0a0c7149a46bf943ccd412da687144b49c6014", // Cat-in-a-Box Finance CDP
+  "0x4a585e0f7c18e2c414221d6402652d5e0990e5f8", // maverick pools wrapper
 ];
 
 export const WHITE_LIST_ADDRESSES: string[] = WHITE_LIST_ADDRESSES_RAW.map(


### PR DESCRIPTION
The contract wraps calls to maveric's pools, e.g. [this](https://etherscan.io/address/0x85dd09159b42417c1e0782fa2c6ba3b790be9ead) and [this](https://etherscan.io/address/0xcb2e6adc815195069977692de2f6e22e920a6b1b) by calling smth like `swap` on them:
```solidity
        <...>swap(...) {
                uint256 balStable = balanceStable();
                IPrimitiveSwapCallback(msg.sender).swapCallback(0, details.deltaIn, data);
                checkStableBalance(balStable + details.deltaIn);
            }
        }

        emit Swap(
            msg.sender,
            details.recipient,
            details.poolId,
            details.riskyForStable,
            details.deltaIn,
            details.deltaOut
        );
```
<img width="1027" alt="image_2023-03-01_14-59-00" src="https://user-images.githubusercontent.com/10616301/222467170-ff14379c-3909-4f8b-a108-bc72245c3a8d.png">

The pools are on boarded via 1inch, an example of call data for `swap` on 1inch router:

<img width="610" alt="image" src="https://user-images.githubusercontent.com/10616301/222467498-874810a0-26f8-4ce0-a602-b829a1b746e0.png">
 