### PR TITLE
feat: handle sub-agents runs

### DIFF
--- a/ethereum-operations/src/agent.ts
+++ b/ethereum-operations/src/agent.ts
@@ -1,5 +1,4 @@
 import {
-  Initialize,
   BlockEvent,
   TransactionEvent,
   HandleBlock,
@@ -42,9 +41,9 @@ const subAgents: SubAgent[] = [
   agentNORegistry,
 ];
 
-// block or tx handling should take no more than 60 sec.
-// If not all processing is done it will be done later in background
-const handlerResolveTimeout = 60_000;
+// block or tx handling should take no more than 120 sec.
+// If not all processing is done it interrupts the execution, sends current findings and errors as findings too
+const processingTimeout = 120_000;
 
 const maxHandlerRetries = 5;
 
@@ -81,7 +80,7 @@ const initialize = async () => {
   }
 
   await Promise.all(
-    subAgents.map(async (agent, index) => {
+    subAgents.map(async (agent, _) => {
       if (agent.initialize) {
         try {
           const agentMeta = await agent.initialize(blockNumber);
@@ -113,124 +112,109 @@ const initialize = async () => {
   console.log("Bot initialization is done!");
 };
 
+const timeout = async (agent: SubAgent) =>
+  new Promise<never>((_, reject) => {
+    setTimeout(() => {
+      const err = new Error(`Sub-agent ${agent.name} timed out`);
+      reject(err);
+    }, processingTimeout);
+  });
+
 const handleBlock: HandleBlock = async (
   blockEvent: BlockEvent
 ): Promise<Finding[]> => {
-  let responseResolve: (value: Finding[]) => void;
-  let wasResolved = false;
-
-  const response = new Promise<Finding[]>((resolve, _) => {
-    responseResolve = resolve;
-  });
-
-  // we need to resolve Promise in handlerResolveTimeout maximum.
-  // If not all handlers have finished execution we will leave them working in background
-  const blockHandlingTimeout = setTimeout(function () {
-    console.log(
-      `block ${blockEvent.blockNumber} processing moved to the background due to timeout`
-    );
-    responseResolve(blockFindingsCache.splice(0, blockFindingsCache.length));
-    wasResolved = true;
-  }, handlerResolveTimeout);
-
   // report findings from init. Will be done only for the first block report.
   if (findingsOnInit.length) {
     blockFindingsCache = findingsOnInit;
     findingsOnInit = [];
   }
 
-  // run agents handlers
-  Promise.all(
-    subAgents.map(async (agent) => {
-      if (agent.handleBlock) {
-        let retries = maxHandlerRetries;
-        let success = false;
-        let lastError;
-        while (retries-- > 0 && !success) {
-          try {
-            const newFindings = await agent.handleBlock(blockEvent);
-            if (newFindings.length) {
-              enrichFindingsMetadata(newFindings);
-              blockFindingsCache = blockFindingsCache.concat(newFindings);
-            }
-            success = true;
-          } catch (err) {
-            lastError = err;
-          }
+  const run = async (agent: SubAgent, blockEvent: BlockEvent) => {
+    if (!agent.handleBlock) return;
+    let retries = maxHandlerRetries;
+    let success = false;
+    let lastError;
+    while (retries-- > 0 && !success) {
+      try {
+        const newFindings = await agent.handleBlock(blockEvent);
+        if (newFindings.length) {
+          enrichFindingsMetadata(newFindings);
+          blockFindingsCache = blockFindingsCache.concat(newFindings);
         }
-        if (!success) {
-          blockFindingsCache.push(
-            errorToFinding(lastError, agent, "handleBlock")
-          );
-        }
+        success = true;
+      } catch (err) {
+        lastError = err;
       }
+    }
+    if (!success) {
+      blockFindingsCache.push(errorToFinding(lastError, agent, "handleBlock"));
+    }
+  };
+
+  // run agents handlers
+  // wait all results whether success or failure (include timeout errors)
+
+  const runs = await Promise.allSettled(
+    subAgents.map(async (agent) => {
+      return await Promise.race([run(agent, blockEvent), timeout(agent)]);
     })
-  ).then(() => {
-    if (wasResolved) return;
-    // if all handlers have finished execution drop timeout and resolve promise
-    clearTimeout(blockHandlingTimeout);
-    responseResolve(blockFindingsCache.splice(0, blockFindingsCache.length));
-    wasResolved = true; // should not be reached, but to make sure
+  );
+
+  runs.forEach((r: PromiseSettledResult<any>, index: number) => {
+    if (r.status == "rejected") {
+      blockFindingsCache.push(
+        errorToFinding(r.reason, subAgents[index], "handleBlock")
+      );
+    }
   });
 
-  return response;
+  return blockFindingsCache.splice(0, blockFindingsCache.length);
 };
 
 const handleTransaction: HandleTransaction = async (
   txEvent: TransactionEvent
 ) => {
-  let responseResolve: (value: Finding[]) => void;
-  let wasResolved = false;
-
-  const response = new Promise<Finding[]>((resolve, _) => {
-    responseResolve = resolve;
-  });
-
-  // we need to resolve Promise in handlerResolveTimeout maximum.
-  // If not all handlers has finished execution we will left them working in background
-  const txHandlingTimeout = setTimeout(function () {
-    console.log(
-      `transaction ${txEvent.transaction.hash} processing moved to the background due to timeout`
-    );
-    responseResolve(txFindingsCache.splice(0, txFindingsCache.length));
-    wasResolved = true;
-  }, handlerResolveTimeout);
+  const run = async (agent: SubAgent, txEvent: TransactionEvent) => {
+    if (!agent.handleTransaction) return;
+    let retries = maxHandlerRetries;
+    let success = false;
+    let lastError;
+    while (retries-- > 0 && !success) {
+      try {
+        const newFindings = await agent.handleTransaction(txEvent);
+        if (newFindings.length) {
+          enrichFindingsMetadata(newFindings);
+          txFindingsCache = txFindingsCache.concat(newFindings);
+        }
+        success = true;
+      } catch (err) {
+        lastError = err;
+      }
+    }
+    if (!success) {
+      txFindingsCache.push(
+        errorToFinding(lastError, agent, "handleTransaction")
+      );
+    }
+  };
 
   // run agents handlers
-  Promise.all(
+  // wait all results whether success or failure (include timeout errors)
+  const runs = await Promise.allSettled(
     subAgents.map(async (agent) => {
-      if (agent.handleTransaction) {
-        let retries = maxHandlerRetries;
-        let success = false;
-        let lastError;
-        while (retries-- > 0 && !success) {
-          try {
-            const newFindings = await agent.handleTransaction(txEvent);
-            if (newFindings.length) {
-              enrichFindingsMetadata(newFindings);
-              txFindingsCache = txFindingsCache.concat(newFindings);
-            }
-            success = true;
-          } catch (err) {
-            lastError = err;
-          }
-        }
-        if (!success) {
-          txFindingsCache.push(
-            errorToFinding(lastError, agent, "handleTransaction")
-          );
-        }
-      }
+      return await Promise.race([run(agent, txEvent), timeout(agent)]);
     })
-  ).then(() => {
-    if (wasResolved) return;
-    // if all handlers have finished execution drop timeout and resolve promise
-    clearTimeout(txHandlingTimeout);
-    responseResolve(txFindingsCache.splice(0, txFindingsCache.length));
-    wasResolved = true; // should not be reached, but to make sure
+  );
+
+  runs.forEach((r: PromiseSettledResult<any>, index: number) => {
+    if (r.status == "rejected") {
+      txFindingsCache.push(
+        errorToFinding(r.reason, subAgents[index], "handleBlock")
+      );
+    }
   });
 
-  return response;
+  return txFindingsCache.splice(0, txFindingsCache.length);
 };
 
 function enrichFindingsMetadata(findings: Finding[]) {

--- a/ethereum-operations/src/agent.ts
+++ b/ethereum-operations/src/agent.ts
@@ -192,9 +192,7 @@ const handleTransaction: HandleTransaction = async (
       }
     }
     if (!success) {
-      txFindings.push(
-        errorToFinding(lastError, agent, "handleTransaction")
-      );
+      txFindings.push(errorToFinding(lastError, agent, "handleTransaction"));
     }
   };
 


### PR DESCRIPTION
Now we don't keep hanging runs in the background. We interrupt them by timeout and put corresponding errors into the findings