### PR TITLE
feat: new rebase digest

### DIFF
--- a/ethereum-operations/e2e/__snapshots__/agent-dao-ops.e2e-spec.ts.snap
+++ b/ethereum-operations/e2e/__snapshots__/agent-dao-ops.e2e-spec.ts.snap
@@ -120,22 +120,6 @@ exports[`agent-dao-ops e2e tests should process tx with changed owner of the con
 
 exports[`agent-dao-ops e2e tests should process tx with changed protocol contracts 1`] = `undefined`;
 
-exports[`agent-dao-ops e2e tests should process tx with received EL rewards 1`] = `
-Finding {
-  "addresses": Array [],
-  "alertId": "LIDO-EL-REWARDS-RECEIVED",
-  "description": "Rewards amount: 142.21 ETH",
-  "labels": Array [],
-  "metadata": Object {
-    "args": "142210964953261078203",
-  },
-  "name": "✅ Lido: EL rewards received",
-  "protocol": "ethereum",
-  "severity": 1,
-  "type": 4,
-}
-`;
-
 exports[`agent-dao-ops e2e tests should process tx with transferred ownership of Insurance fund 1`] = `
 Array [
   Finding {

--- a/ethereum-operations/e2e/__snapshots__/agent-lido-report.e2e-spec.ts.snap
+++ b/ethereum-operations/e2e/__snapshots__/agent-lido-report.e2e-spec.ts.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`agent-lido-report e2e tests should process tx with Lido rebase digest 1`] = `
+Finding {
+  "addresses": Array [],
+  "alertId": "LIDO-REPORT-REBASE-DIGEST",
+  "description": "*APR stats*
+APR: 5.26%
+Total shares: 5646066.679 -> 5644434.777 1e18 (-0.03%)
+Total pooled ether: 6349026.643 -> 6348106.239 ETH (-0.01%)
+Time elapsed: 24 hrs 0 sec
+
+*Rewards*
+CL rewards: 623.374 (+0.248) ETH
+EL rewards: 392.917 (+51.693) ETH
+Total: 1016.291 (+51.940) ETH
+
+*Validators*
+Count: 196087 (0 newly appeared)
+
+*Withdrawn from*
+Withdrawal Vault: 756.285 ETH
+EL Vault: 392.917 ETH
+Buffer: 787.493 ETH
+
+*Requests finalization*
+Finalized: 41
+Ether: 1936.695 ETH
+Share rate: 1.12467
+
+*Shares*
+Burnt: 1722.266 1e18",
+  "labels": Array [],
+  "metadata": Object {},
+  "name": "ℹ️ Lido Report: rebase digest",
+  "protocol": "ethereum",
+  "severity": 1,
+  "type": 4,
+}
+`;

--- a/ethereum-operations/e2e/agent-dao-ops.e2e-spec.ts
+++ b/ethereum-operations/e2e/agent-dao-ops.e2e-spec.ts
@@ -186,18 +186,6 @@ describe("agent-dao-ops e2e tests", () => {
   );
 
   it(
-    "should process tx with received EL rewards",
-    async () => {
-      let findings = await runTransaction(
-        "0x60a7671264723099c564d33b04af6617195093531f012941e75c372dcb9ba242"
-      );
-      findings.sort();
-      expect(findings.at(0)).toMatchSnapshot();
-    },
-    TEST_TIMEOUT
-  );
-
-  it(
     "should process tx with EL rewards withdrawal limit set",
     async () => {
       let findings = await runTransaction(

--- a/ethereum-operations/e2e/agent-lido-report.e2e-spec.ts
+++ b/ethereum-operations/e2e/agent-lido-report.e2e-spec.ts
@@ -60,4 +60,15 @@ describe("agent-lido-report e2e tests", () => {
     },
     TEST_TIMEOUT
   );
+
+  it(
+    "should process tx with Lido rebase digest",
+    async () => {
+      const findings = await runTransaction(
+        "0xbf52777e4dd583d52104be96f7da420be977faeee97cc25a89d6c81fa919056f"
+      );
+      expect(findings.at(0)).toMatchSnapshot();
+    },
+    TEST_TIMEOUT
+  );
 });

--- a/ethereum-operations/src/subagents/dao-ops/constants.ts
+++ b/ethereum-operations/src/subagents/dao-ops/constants.ts
@@ -150,28 +150,6 @@ export const LIDO_EVENTS_OF_NOTICE = [
   },
   {
     address: LIDO_ADDRESS,
-    event: "event ELRewardsReceived(uint256 amount)",
-    alertId: "LIDO-EL-REWARDS-RECEIVED",
-    name: "✅ Lido: EL rewards received",
-    description: (args: any) =>
-      `Rewards amount: ${new BigNumber(String(args.amount))
-        .div(ETH_DECIMALS)
-        .toFixed(2)} ETH`,
-    severity: FindingSeverity.Info,
-  },
-  {
-    address: LIDO_ADDRESS,
-    event: "event WithdrawalsReceived(uint256 amount)",
-    alertId: "LIDO-WITHDRAWALS-RECEIVED",
-    name: "✅ Lido: Withdrawals received",
-    description: (args: any) =>
-      `Withdrawals amount: ${new BigNumber(String(args.amount))
-        .div(ETH_DECIMALS)
-        .toFixed(2)} ETH`,
-    severity: FindingSeverity.Info,
-  },
-  {
-    address: LIDO_ADDRESS,
     event: "event RecoverToVault(address vault, address token, uint256 amount)",
     alertId: "LIDO-RECOVER-TO-VAULT",
     name: "ℹ️ Lido: Funds recovered to vault",

--- a/ethereum-operations/src/subagents/lido-report/agent-lido-report.ts
+++ b/ethereum-operations/src/subagents/lido-report/agent-lido-report.ts
@@ -636,7 +636,7 @@ function prepareSharesBurntLines(txEvent: TransactionEvent): string {
     LIDO_ADDRESS
   );
   if (!sharesBurntEvent) {
-    return `*Shares*\nBurnt: 0.000 1e18`;
+    return `*Shares*\nNo shares burnt`;
   }
   const sharesBurnt = sharesBurntEvent
     ? new BigNumber(String(sharesBurntEvent.args.sharesAmount)).div(

--- a/ethereum-operations/src/subagents/lido-report/agent-lido-report.ts
+++ b/ethereum-operations/src/subagents/lido-report/agent-lido-report.ts
@@ -36,6 +36,9 @@ const {
   NODE_OPERATOR_REGISTRY_MODULE_ID,
   ACCOUNTING_ORACLE_EXTRA_DATA_SUBMITTED_EVENT,
   LIDO_ETHDESTRIBUTED_EVENT,
+  LIDO_ELREWARDSRECEIVED_EVENT,
+  LIDO_WITHDRAWALSRECEIVED_EVENT,
+  LIDO_VALIDATORS_UPDATED_EVENT,
   LIDO_SHARES_BURNT_EVENT,
   LIDO_TOKEN_REBASED_EVENT,
   WITHDRAWAL_QUEUE_WITHDRAWALS_FINALIZED_EVENT,
@@ -55,7 +58,8 @@ const {
 export const name = "LidoReport";
 
 // re-fetched from history on startup
-let lastCLrewards = new BigNumber(0);
+let lastCLrewards = BN_ZERO;
+let lastELrewards = BN_ZERO;
 let lastAllExited = 0;
 let lastAllStuck = 0;
 let lastAllRefunded = 0;
@@ -89,12 +93,34 @@ export async function initialize(
     currentBlock - 1
   );
   if (ethDistributedEvents.length > 0) {
-    const { preCLBalance, postCLBalance, withdrawalsWithdrawn } =
-      ethDistributedEvents[ethDistributedEvents.length - 1].args as any;
+    const lastEvent = ethDistributedEvents[ethDistributedEvents.length - 1];
+
+    const [withdrawalsReceivedEvent] = await lido.queryFilter(
+      lido.filters.WithdrawalsReceived(),
+      lastEvent.blockNumber,
+      lastEvent.blockNumber
+    );
+
+    const [elRewardsReceivedEvent] = await lido.queryFilter(
+      lido.filters.ELRewardsReceived(),
+      lastEvent.blockNumber,
+      lastEvent.blockNumber
+    );
+
+    const { preCLBalance, postCLBalance } = ethDistributedEvents[
+      ethDistributedEvents.length - 1
+    ].args as any;
+
     lastCLrewards = new BigNumber(String(postCLBalance))
       .minus(String(preCLBalance))
-      .plus(String(withdrawalsWithdrawn))
+      .plus(
+        String(new BigNumber(String(withdrawalsReceivedEvent.args?.amount)))
+      )
       .div(ETH_DECIMALS);
+
+    lastELrewards = new BigNumber(
+      String(elRewardsReceivedEvent.args?.amount)
+    ).div(ETH_DECIMALS);
   }
 
   return {};
@@ -228,9 +254,9 @@ async function handleBurnerUnburntSharesOverfill(
           name: `⚠️ Burner overfilled: unburnt shares are more than ${OVERFILL_THRESHOLD_PERCENT}% of total shares`,
           description: `Unburnt: ${unburntShares
             .div(ETH_DECIMALS)
-            .toFixed(3)} ETH\nTotal shares: ${totalShares
+            .toFixed(3)} 1e18\nTotal shares: ${totalShares
             .div(ETH_DECIMALS)
-            .toFixed(3)} ETH`,
+            .toFixed(3)} 1e18`,
           alertId: "LIDO-BURNER-UNBURNT-OVERFILLED",
           severity: FindingSeverity.Medium,
           type: FindingType.Info,
@@ -246,20 +272,80 @@ export async function handleTransaction(txEvent: TransactionEvent) {
 
   if (txEvent.to === ACCOUNTING_ORACLE_ADDRESS) {
     await handleExitedStuckRefundedKeysDigest(txEvent, findings);
-    handleWithdrawalsFinalizationDigest(txEvent, findings);
-    handleRebaseDigest(txEvent, findings);
-    handleAPR(txEvent, findings);
+    await handleRebaseDigest(txEvent, findings);
   }
 
   return findings;
 }
 
-function handleAPR(txEvent: TransactionEvent, findings: Finding[]) {
+async function handleExitedStuckRefundedKeysDigest(
+  txEvent: TransactionEvent,
+  findings: Finding[]
+) {
+  const [extraDataSubmittedEvent] = txEvent.filterLog(
+    ACCOUNTING_ORACLE_EXTRA_DATA_SUBMITTED_EVENT,
+    ACCOUNTING_ORACLE_ADDRESS
+  );
+  if (!extraDataSubmittedEvent) return;
+  const { allExited, allStuck, allRefunded } = await getSummaryDigest(
+    txEvent.blockNumber
+  );
+  const newExited = allExited - lastAllExited;
+  const newStuck = allStuck - lastAllStuck;
+  const newRefunded = allRefunded - lastAllRefunded;
+  if (newExited == 0 && newStuck == 0 && newRefunded == 0) return;
+  findings.push(
+    Finding.fromObject({
+      name: "ℹ️ Lido Report: new exited, stuck and refunded keys digest",
+      description: `New exited: ${newExited}\nNew stuck: ${newStuck}\nNew refunded: ${newRefunded}`,
+      alertId: "LIDO-REPORT-EXITED-STUCK-REFUNDED-KEYS-DIGEST",
+      severity: FindingSeverity.Info,
+      type: FindingType.Info,
+    })
+  );
+  lastAllStuck = allStuck;
+  lastAllRefunded = allRefunded;
+  lastAllExited = allExited;
+}
+
+async function handleRebaseDigest(
+  txEvent: TransactionEvent,
+  findings: Finding[]
+) {
+  const [ethDistributedEvent] = txEvent.filterLog(
+    LIDO_ETHDESTRIBUTED_EVENT,
+    LIDO_ADDRESS
+  );
+  if (!ethDistributedEvent) return;
+
+  const lines = [
+    prepareAPRLines(txEvent, findings),
+    prepareRewardsLines(txEvent, findings),
+    prepareValidatorsCountLines(txEvent),
+    await prepareWithdrawnLines(txEvent),
+    prepareRequestsFinalizationLines(txEvent),
+    prepareSharesBurntLines(txEvent),
+  ];
+
+  findings.push(
+    Finding.fromObject({
+      name: "ℹ️ Lido Report: rebase digest",
+      description: lines.filter((l) => l != undefined).join("\n\n"),
+      alertId: "LIDO-REPORT-REBASE-DIGEST",
+      severity: FindingSeverity.Info,
+      type: FindingType.Info,
+    })
+  );
+}
+
+function prepareAPRLines(
+  txEvent: TransactionEvent,
+  findings: Finding[]
+): string | undefined {
   const [tokenRebasedEvent] = txEvent.filterLog(
     LIDO_TOKEN_REBASED_EVENT,
     LIDO_ADDRESS
   );
-  if (!tokenRebasedEvent) return;
   lastRebaseEventTimestamp = txEvent.block.timestamp;
   let timeElapsed = new BigNumber(String(tokenRebasedEvent.args.timeElapsed));
   let preTotalShares = new BigNumber(
@@ -293,8 +379,6 @@ function handleAPR(txEvent: TransactionEvent, findings: Finding[]) {
       ? `+${etherDiffPercent.toFixed(2)}`
       : etherDiffPercent.toFixed(2);
 
-  let severity = FindingSeverity.Info;
-  let name = "ℹ️ Lido Report: APR stats";
   const apr = calculateAPR(
     timeElapsed,
     preTotalShares,
@@ -302,113 +386,124 @@ function handleAPR(txEvent: TransactionEvent, findings: Finding[]) {
     postTotalShares,
     postTotalEther
   );
+
+  let findingName: string = "";
+  let findingSeverity: FindingSeverity = FindingSeverity.Info;
+  let digestAprStr = `APR: ${apr.times(100).toFixed(2)}%`;
   if (apr.gte(LIDO_REPORT_LIMIT_REACHED_APR_THRESHOLD)) {
-    name = `⚠️ Lido Report: APR is greater than ${
+    findingName = `🚨️ Lido Report: APR is greater than ${
       LIDO_REPORT_LIMIT_REACHED_APR_THRESHOLD * 100
     }% limit`;
-    severity = FindingSeverity.High;
+    digestAprStr += ` 🚨️ > ${LIDO_REPORT_LIMIT_REACHED_APR_THRESHOLD * 100}%`;
+    findingSeverity = FindingSeverity.High;
   } else if (apr.gte(LIDO_REPORT_HIGH_APR_THRESHOLD)) {
-    name = `⚠️ Lido Report: APR is greater than ${
+    findingName = `⚠️ Lido Report: APR is greater than ${
       LIDO_REPORT_HIGH_APR_THRESHOLD * 100
     }%`;
-    severity = FindingSeverity.Medium;
+    digestAprStr += ` ⚠️ > ${LIDO_REPORT_HIGH_APR_THRESHOLD * 100}%`;
+    findingSeverity = FindingSeverity.Medium;
   } else if (apr.lte(LIDO_REPORT_LOW_APR_THRESHOLD)) {
-    name = `⚠️ Lido Report: APR is less than ${
+    findingName = `🚨️️ Lido Report: APR is less than ${
       LIDO_REPORT_LOW_APR_THRESHOLD * 100
     }%`;
-    severity = FindingSeverity.High;
+    digestAprStr += ` 🚨 < ${LIDO_REPORT_LOW_APR_THRESHOLD * 100}%`;
+    findingSeverity = FindingSeverity.High;
   }
 
-  findings.push(
-    Finding.fromObject({
-      name: name,
-      alertId: "LIDO-REPORT-APR-STATS",
-      description: `APR: ${apr
-        .times(100)
-        .toFixed(2)}%\nTime elapsed: ${formatDelay(
-        Number(timeElapsed)
-      )}\nTotal shares: ${preTotalShares
-        .div(ETH_DECIMALS)
-        .toFixed(3)} -> ${postTotalShares
-        .div(ETH_DECIMALS)
-        .toFixed(
-          3
-        )} ETH (${strSharesDiffPercent}%)\nTotal ether: ${preTotalEther
-        .div(ETH_DECIMALS)
-        .toFixed(3)} -> ${postTotalEther
-        .div(ETH_DECIMALS)
-        .toFixed(3)} ETH (${strEtherDiffPercent}%)`,
-      severity: severity,
-      type: FindingType.Info,
-    })
-  );
+  const additionalDescription = `Total shares: ${preTotalShares
+    .div(ETH_DECIMALS)
+    .toFixed(3)} -> ${postTotalShares
+    .div(ETH_DECIMALS)
+    .toFixed(3)} 1e18 (${strSharesDiffPercent}%)\nTotal ether: ${preTotalEther
+    .div(ETH_DECIMALS)
+    .toFixed(3)} -> ${postTotalEther
+    .div(ETH_DECIMALS)
+    .toFixed(3)} ETH (${strEtherDiffPercent}%)\nTime elapsed: ${formatDelay(
+    Number(timeElapsed)
+  )}`;
+
+  if (findingName != "") {
+    findings.push(
+      Finding.fromObject({
+        name: findingName,
+        alertId: "LIDO-UNUSUAL-REPORT-APR-STATS",
+        description: `APR: ${apr
+          .times(100)
+          .toFixed(2)}%\n${additionalDescription}`,
+        severity: findingSeverity,
+        type: FindingType.Info,
+      })
+    );
+  }
+
+  return `*APR stats*\n${digestAprStr}\n${additionalDescription}`;
 }
 
-function handleRebaseDigest(txEvent: TransactionEvent, findings: Finding[]) {
+function prepareRewardsLines(
+  txEvent: TransactionEvent,
+  findings: Finding[]
+): string {
   const [ethDistributedEvent] = txEvent.filterLog(
     LIDO_ETHDESTRIBUTED_EVENT,
     LIDO_ADDRESS
   );
-  if (!ethDistributedEvent) return;
-  const [sharesBurntEvent] = txEvent.filterLog(
-    LIDO_SHARES_BURNT_EVENT,
+  const [withdrawalsReceivedEvent] = txEvent.filterLog(
+    LIDO_WITHDRAWALSRECEIVED_EVENT,
     LIDO_ADDRESS
   );
-  const sharesBurnt = sharesBurntEvent
-    ? new BigNumber(String(sharesBurntEvent.args.sharesAmount)).div(
-        ETH_DECIMALS
-      )
-    : new BigNumber(0);
-  const {
-    preCLBalance,
-    postCLBalance,
-    withdrawalsWithdrawn,
-    executionLayerRewardsWithdrawn,
-  } = ethDistributedEvent.args;
-  const clRewards = new BigNumber(String(postCLBalance))
-    .minus(new BigNumber(String(preCLBalance)))
-    .plus(new BigNumber(String(withdrawalsWithdrawn)))
-    .div(ETH_DECIMALS);
-  const elRewards = new BigNumber(String(executionLayerRewardsWithdrawn)).div(
-    ETH_DECIMALS
-  );
-  const withdrawals = new BigNumber(String(withdrawalsWithdrawn)).div(
-    ETH_DECIMALS
+  const [elRewardsReceivedEvent] = txEvent.filterLog(
+    LIDO_ELREWARDSRECEIVED_EVENT,
+    LIDO_ADDRESS
   );
 
+  const { preCLBalance, postCLBalance } = ethDistributedEvent.args;
+  const clValidatorsBalanceDiff = new BigNumber(String(postCLBalance)).minus(
+    new BigNumber(String(preCLBalance))
+  );
+  const withdrawalsReceived = new BigNumber(
+    String(withdrawalsReceivedEvent.args.amount)
+  );
+  const clRewards = clValidatorsBalanceDiff
+    .plus(withdrawalsReceived)
+    .div(ETH_DECIMALS);
+  const elRewards = new BigNumber(
+    String(elRewardsReceivedEvent.args.amount)
+  ).div(ETH_DECIMALS);
+
   lastCLrewards = lastCLrewards.eq(BN_ZERO) ? clRewards : lastCLrewards;
+  lastELrewards = lastELrewards.eq(BN_ZERO) ? elRewards : lastELrewards;
   const clRewardsDiff = clRewards.minus(lastCLrewards);
+  const elRewardsDiff = elRewards.minus(lastELrewards);
+  const totalRewardsDiff = clRewardsDiff.plus(elRewardsDiff);
   const strCLRewardsDiff =
     Number(clRewardsDiff) > 0
       ? `+${clRewardsDiff.toFixed(3)}`
       : clRewardsDiff.toFixed(3);
+  const strELRewardsDiff =
+    Number(elRewardsDiff) > 0
+      ? `+${elRewardsDiff.toFixed(3)}`
+      : elRewardsDiff.toFixed(3);
+  const strTotalRewardsDiff =
+    Number(totalRewardsDiff) > 0
+      ? `+${totalRewardsDiff.toFixed(3)}`
+      : totalRewardsDiff.toFixed(3);
 
-  findings.push(
-    Finding.fromObject({
-      name: "ℹ️ Lido Report: rebase digest",
-      description: `CL rewards (includes withdrawn from WithdrawalVault): ${clRewards.toFixed(
-        3
-      )} ETH (${strCLRewardsDiff} ETH)\nWithdrawn EL rewards: ${elRewards.toFixed(
-        3
-      )} ETH\nWithdrawn from WithdrawalVault: ${withdrawals.toFixed(
-        3
-      )} ETH\nShares burnt: ${sharesBurnt.toFixed(3)} ETH`,
-      alertId: "LIDO-REPORT-REBASE-DIGEST",
-      severity: FindingSeverity.Info,
-      type: FindingType.Info,
-    })
-  );
+  let strCLRewards = `CL rewards: ${clRewards.toFixed(
+    3
+  )} (${strCLRewardsDiff}) ETH`;
 
   const clRewardsDiffPercent = clRewardsDiff.div(lastCLrewards).times(100);
   const strCLRewardsDiffPercent =
     Number(clRewardsDiffPercent) > 0
       ? `+${clRewardsDiffPercent.toFixed(2)}`
       : clRewardsDiffPercent.toFixed(2);
-
   if (
     Number(clRewardsDiffPercent) <
     -LIDO_REPORT_CL_REWARDS_DIFF_PERCENT_THRESHOLD_MEDIUM
   ) {
+    strCLRewards =
+      `️CL rewards: ${clRewards.toFixed(3)} ETH 🚨️ decreased ` +
+      `by ${clRewardsDiff.toFixed(3)} ETH (${strCLRewardsDiffPercent}%)`;
     const severity =
       Number(clRewardsDiffPercent) <
       -LIDO_REPORT_CL_REWARDS_DIFF_PERCENT_THRESHOLD_HIGH
@@ -430,67 +525,118 @@ function handleRebaseDigest(txEvent: TransactionEvent, findings: Finding[]) {
   }
 
   lastCLrewards = clRewards;
+  lastELrewards = elRewards;
+
+  return `*Rewards*\n${strCLRewards}\nEL rewards: ${elRewards.toFixed(
+    3
+  )} (${strELRewardsDiff}) ETH\nTotal: ${clRewards
+    .plus(elRewards)
+    .toFixed(3)} (${strTotalRewardsDiff}) ETH`;
 }
 
-async function handleExitedStuckRefundedKeysDigest(
-  txEvent: TransactionEvent,
-  findings: Finding[]
-) {
-  const [extraDataSubmittedEvent] = txEvent.filterLog(
-    ACCOUNTING_ORACLE_EXTRA_DATA_SUBMITTED_EVENT,
-    ACCOUNTING_ORACLE_ADDRESS
+function prepareValidatorsCountLines(txEvent: TransactionEvent): string {
+  const [validatorsUpdated] = txEvent.filterLog(
+    LIDO_VALIDATORS_UPDATED_EVENT,
+    LIDO_ADDRESS
   );
-  if (!extraDataSubmittedEvent) return;
-  const { allExited, allStuck, allRefunded } = await getSummaryDigest(
-    txEvent.blockNumber
-  );
-  const newExited = allExited - lastAllExited;
-  const newStuck = allStuck - lastAllStuck;
-  const newRefunded = allRefunded - lastAllRefunded;
-  if (newExited == 0 && newStuck == 0 && newRefunded == 0) return;
-  findings.push(
-    Finding.fromObject({
-      name: "ℹ️ Lido Report: new exited, stuck and refunded keys digest",
-      description: `New exited: ${newExited}\nNew stuck: ${newStuck}\nNew refunded: ${newRefunded}`,
-      alertId: "LIDO-REPORT-EXITED-STUCK-REFUNDED-KEYS-DIGEST",
-      severity: FindingSeverity.Info,
-      type: FindingType.Info,
-    })
-  );
-  lastAllStuck = allStuck;
-  lastAllRefunded = allRefunded;
-  lastAllExited = allExited;
+  const { preCLValidators, postCLValidators } = validatorsUpdated.args;
+  return `*Validators*\nCount: ${postCLValidators} (${
+    Number(postCLValidators) - Number(preCLValidators)
+  } newly appeared)`;
 }
 
-function handleWithdrawalsFinalizationDigest(
-  txEvent: TransactionEvent,
-  findings: Finding[]
-) {
+async function prepareWithdrawnLines(
+  txEvent: TransactionEvent
+): Promise<string> {
+  const [ethDistributedEvent] = txEvent.filterLog(
+    LIDO_ETHDESTRIBUTED_EVENT,
+    LIDO_ADDRESS
+  );
+  const [elRewardsReceivedEvent] = txEvent.filterLog(
+    LIDO_ELREWARDSRECEIVED_EVENT,
+    LIDO_ADDRESS
+  );
+
+  const elRewardsReceived = new BigNumber(
+    String(elRewardsReceivedEvent.args.amount)
+  );
+
+  const {
+    withdrawalsWithdrawn,
+    executionLayerRewardsWithdrawn,
+    postBufferedEther,
+  } = ethDistributedEvent.args;
+  const wdWithdrawn = new BigNumber(String(withdrawalsWithdrawn)).div(
+    ETH_DECIMALS
+  );
+  const elWithdrawn = new BigNumber(String(executionLayerRewardsWithdrawn));
+  const elWithdrawnReceivedDiff = elRewardsReceived.minus(elWithdrawn);
+
+  const lido = new ethers.Contract(LIDO_ADDRESS, LIDO_ABI, ethersProvider);
+  const preBufferedEther = await lido.functions.getBufferedEther({
+    blockTag: txEvent.blockNumber - 1,
+  });
+  const bufferDiff = new BigNumber(String(postBufferedEther)).minus(
+    preBufferedEther
+  );
+
+  return `*Withdrawn from*\nWithdrawal Vault: ${wdWithdrawn.toFixed(
+    3
+  )} ETH\nEL Vault: ${elWithdrawn.div(ETH_DECIMALS).toFixed(3)} ETH${
+    elWithdrawnReceivedDiff.gt(0)
+      ? ` ⚠️ ${elWithdrawnReceivedDiff
+          .div(ETH_DECIMALS)
+          .toFixed(3)} ETH left on the vault`
+      : ""
+  }\nBuffer: ${
+    bufferDiff.lt(0)
+      ? bufferDiff.times(-1).div(ETH_DECIMALS).toFixed(3)
+      : "0.000"
+  } ETH`;
+}
+
+function prepareRequestsFinalizationLines(
+  txEvent: TransactionEvent
+): string | undefined {
   const [withdrawalsFinalizedEvent] = txEvent.filterLog(
     WITHDRAWAL_QUEUE_WITHDRAWALS_FINALIZED_EVENT,
     WITHDRAWAL_QUEUE_ADDRESS
   );
   if (!withdrawalsFinalizedEvent) return;
-  const { from, to, amountOfETHLocked, sharesToBurn } =
-    withdrawalsFinalizedEvent.args;
+  const [tokenRebasedEvent] = txEvent.filterLog(
+    LIDO_TOKEN_REBASED_EVENT,
+    LIDO_ADDRESS
+  );
+  const { postTotalEther, postTotalShares } = tokenRebasedEvent.args;
+  const { from, to, amountOfETHLocked } = withdrawalsFinalizedEvent.args;
   const ether = new BigNumber(String(amountOfETHLocked)).div(ETH_DECIMALS);
-  const shares = new BigNumber(String(sharesToBurn)).div(ETH_DECIMALS);
   const requests = Number(to) - Number(from);
+  const shareRate = new BigNumber(String(postTotalEther)).div(
+    new BigNumber(String(postTotalShares))
+  );
   let description = "No one finalized requests";
   if (requests > 0) {
-    description = `Requests: ${
+    description = `Finalized: ${
       Number(to) - Number(from)
-    }\nShares: ${shares.toFixed(2)} ETH\nEther: ${ether.toFixed(2)} ETH`;
+    }\nEther: ${ether.toFixed(3)} ETH\nShare rate: ${shareRate.toFixed(5)}`;
   }
-  findings.push(
-    Finding.fromObject({
-      name: "ℹ️ Lido Report: withdrawals finalization digest",
-      description: description,
-      alertId: "LIDO-REPORT-WITHDRAWALS-FINALIZATION-DIGEST",
-      severity: FindingSeverity.Info,
-      type: FindingType.Info,
-    })
+  return `*Requests finalisation*\n${description}`;
+}
+
+function prepareSharesBurntLines(
+  txEvent: TransactionEvent
+): string | undefined {
+  const [sharesBurntEvent] = txEvent.filterLog(
+    LIDO_SHARES_BURNT_EVENT,
+    LIDO_ADDRESS
   );
+  if (!sharesBurntEvent) return;
+  const sharesBurnt = sharesBurntEvent
+    ? new BigNumber(String(sharesBurntEvent.args.sharesAmount)).div(
+        ETH_DECIMALS
+      )
+    : new BigNumber(0);
+  return `*Shares*\nBurnt: ${sharesBurnt.toFixed(3)} 1e18`;
 }
 
 async function getSummaryDigest(block: number) {

--- a/ethereum-operations/src/subagents/lido-report/constants.ts
+++ b/ethereum-operations/src/subagents/lido-report/constants.ts
@@ -17,6 +17,12 @@ export const NODE_OPERATOR_REGISTRY_MODULE_ID = 1;
 
 export const LIDO_ETHDESTRIBUTED_EVENT =
   "event ETHDistributed(uint256 indexed reportTimestamp, uint256 preCLBalance, uint256 postCLBalance, uint256 withdrawalsWithdrawn, uint256 executionLayerRewardsWithdrawn, uint256 postBufferedEther)";
+export const LIDO_ELREWARDSRECEIVED_EVENT =
+  "event ELRewardsReceived(uint256 amount)";
+export const LIDO_WITHDRAWALSRECEIVED_EVENT =
+  "event WithdrawalsReceived(uint256 amount)";
+export const LIDO_VALIDATORS_UPDATED_EVENT =
+  "event CLValidatorsUpdated(uint256 indexed reportTimestamp, uint256 preCLValidators, uint256 postCLValidators)";
 export const LIDO_SHARES_BURNT_EVENT =
   "event SharesBurnt(address indexed account, uint256 preRebaseTokenAmount, uint256 postRebaseTokenAmount, uint256 sharesAmount)";
 export const LIDO_TOKEN_REBASED_EVENT =


### PR DESCRIPTION
```
ℹ️ Lido Report: rebase digest
*APR stats*
APR: 24.63% ⚠️ > 20%
Total shares: 227887.825 -> 227585.733 1e18 (-0.13%)
Total ether: 257072.970 -> 256905.457 ETH (-0.07%)
Time elapsed: 24 hrs 0 sec

*Rewards*
CL rewards: 20.084 ETH 🚨️ decreased by -1.367 ETH (-6.37%)
EL rewards: 172.721 (+6.891) ETH
Total: 192.805 (+5.524) ETH

*Validators*
Count: 8613 (90 newly appeared)

*Withdrawn from*
Withdrawal Vault: 23.338 ETH
EL Vault: 172.721 ETH
Buffer: 164.259 ETH

*Requests finalisation*
Finalized: 15
Ether: 360.318 ETH
Share rate: 1.12883

*Shares*
Burnt: 319.173 1e18
```