### PR TITLE
chore: Polish digest

### DIFF
--- a/ethereum-operations/e2e/__snapshots__/agent-lido-report.e2e-spec.ts.snap
+++ b/ethereum-operations/e2e/__snapshots__/agent-lido-report.e2e-spec.ts.snap
@@ -6,30 +6,30 @@ Finding {
   "alertId": "LIDO-REPORT-REBASE-DIGEST",
   "description": "*APR stats*
 APR: 5.26%
-Total shares: 5646066.679 -> 5644434.777 1e18 (-0.03%)
-Total pooled ether: 6349026.643 -> 6348106.239 ETH (-0.01%)
+Total shares: 5646066.68 -> 5644434.78 1e18 (-0.03%)
+Total pooled ether: 6349026.64 -> 6348106.24 ETH (-0.01%)
 Time elapsed: 24 hrs 0 sec
 
 *Rewards*
-CL rewards: 623.374 (+0.248) ETH
-EL rewards: 392.917 (+51.693) ETH
-Total: 1016.291 (+51.940) ETH
+CL rewards: 623.37 (+0.25) ETH
+EL rewards: 392.92 (+51.69) ETH
+Total: 1016.29 (+51.94) ETH
 
 *Validators*
 Count: 196087 (0 newly appeared)
 
-*Withdrawn from*
-Withdrawal Vault: 756.285 ETH
-EL Vault: 392.917 ETH
-Buffer: 787.493 ETH
+*Withdrawn from vaults*
+Withdrawal Vault: 756.29 ETH
+EL Vault: 392.92 ETH
 
 *Requests finalization*
 Finalized: 41
-Ether: 1936.695 ETH
+Ether: 1936.70 ETH
 Share rate: 1.12467
+Buffered ether used for withdrawal finalization: 787.49 ETH
 
 *Shares*
-Burnt: 1722.266 1e18",
+Burnt: 1722.27 1e18",
   "labels": Array [],
   "metadata": Object {},
   "name": "ℹ️ Lido Report: rebase digest",

--- a/ethereum-operations/e2e/__snapshots__/agent-lido-report.e2e-spec.ts.snap
+++ b/ethereum-operations/e2e/__snapshots__/agent-lido-report.e2e-spec.ts.snap
@@ -6,7 +6,7 @@ Finding {
   "alertId": "LIDO-REPORT-REBASE-DIGEST",
   "description": "*APR stats*
 APR: 5.26%
-Total shares: 5646066.68 -> 5644434.78 1e18 (-0.03%)
+Total shares: 5646066.68 -> 5644434.78 × 1e18 (-0.03%)
 Total pooled ether: 6349026.64 -> 6348106.24 ETH (-0.01%)
 Time elapsed: 24 hrs 0 sec
 
@@ -29,7 +29,7 @@ Share rate: 1.12467
 Buffered ether used for withdrawal finalization: 787.49 ETH
 
 *Shares*
-Burnt: 1722.27 1e18",
+Burnt: 1722.27 × 1e18",
   "labels": Array [],
   "metadata": Object {},
   "name": "ℹ️ Lido Report: rebase digest",

--- a/ethereum-operations/src/subagents/lido-report/agent-lido-report.ts
+++ b/ethereum-operations/src/subagents/lido-report/agent-lido-report.ts
@@ -254,9 +254,8 @@ async function handleBurnerUnburntSharesOverfill(
         Finding.fromObject({
           name: `⚠️ Burner overfilled: unburnt shares are more than ${OVERFILL_THRESHOLD_PERCENT}% of total shares`,
           description:
-            `Unburnt: ${unburntShares.div(ETH_DECIMALS).toFixed(2)} ` +
-            `1e18\nTotal shares: ${totalShares.div(ETH_DECIMALS).toFixed(2)} ` +
-            `1e18`,
+            `Unburnt: ${unburntShares.div(ETH_DECIMALS).toFixed(2)}×1e18` +
+            `\nTotal shares: ${totalShares.div(ETH_DECIMALS).toFixed(2)}×1e18`,
           alertId: "LIDO-BURNER-UNBURNT-OVERFILLED",
           severity: FindingSeverity.Medium,
           type: FindingType.Info,
@@ -418,7 +417,7 @@ function prepareAPRLines(
     .div(ETH_DECIMALS)
     .toFixed(
       2
-    )} 1e18 (${strSharesDiffPercent}%)\nTotal pooled ether: ${preTotalEther
+    )}×1e18 (${strSharesDiffPercent}%)\nTotal pooled ether: ${preTotalEther
     .div(ETH_DECIMALS)
     .toFixed(2)} -> ${postTotalEther
     .div(ETH_DECIMALS)
@@ -649,7 +648,7 @@ function prepareSharesBurntLines(txEvent: TransactionEvent): string {
         ETH_DECIMALS
       )
     : new BigNumber(0);
-  return `*Shares*\nBurnt: ${sharesBurnt.toFixed(2)} 1e18`;
+  return `*Shares*\nBurnt: ${sharesBurnt.toFixed(2)}×1e18`;
 }
 
 async function getSummaryDigest(block: number) {

--- a/ethereum-operations/src/subagents/lido-report/agent-lido-report.ts
+++ b/ethereum-operations/src/subagents/lido-report/agent-lido-report.ts
@@ -254,8 +254,9 @@ async function handleBurnerUnburntSharesOverfill(
         Finding.fromObject({
           name: `⚠️ Burner overfilled: unburnt shares are more than ${OVERFILL_THRESHOLD_PERCENT}% of total shares`,
           description:
-            `Unburnt: ${unburntShares.div(ETH_DECIMALS).toFixed(2)}×1e18` +
-            `\nTotal shares: ${totalShares.div(ETH_DECIMALS).toFixed(2)}×1e18`,
+            `Unburnt: ${unburntShares.div(ETH_DECIMALS).toFixed(2)} × 1e18` +
+            `\nTotal shares: ` +
+            `${totalShares.div(ETH_DECIMALS).toFixed(2)} × 1e18`,
           alertId: "LIDO-BURNER-UNBURNT-OVERFILLED",
           severity: FindingSeverity.Medium,
           type: FindingType.Info,
@@ -417,7 +418,7 @@ function prepareAPRLines(
     .div(ETH_DECIMALS)
     .toFixed(
       2
-    )}×1e18 (${strSharesDiffPercent}%)\nTotal pooled ether: ${preTotalEther
+    )} × 1e18 (${strSharesDiffPercent}%)\nTotal pooled ether: ${preTotalEther
     .div(ETH_DECIMALS)
     .toFixed(2)} -> ${postTotalEther
     .div(ETH_DECIMALS)
@@ -648,7 +649,7 @@ function prepareSharesBurntLines(txEvent: TransactionEvent): string {
         ETH_DECIMALS
       )
     : new BigNumber(0);
-  return `*Shares*\nBurnt: ${sharesBurnt.toFixed(2)}×1e18`;
+  return `*Shares*\nBurnt: ${sharesBurnt.toFixed(2)} × 1e18`;
 }
 
 async function getSummaryDigest(block: number) {

--- a/ethereum-operations/src/subagents/lido-report/agent-lido-report.ts
+++ b/ethereum-operations/src/subagents/lido-report/agent-lido-report.ts
@@ -324,7 +324,7 @@ async function handleRebaseDigest(
     prepareAPRLines(txEvent, findings),
     prepareRewardsLines(txEvent, findings),
     prepareValidatorsCountLines(txEvent),
-    await prepareWithdrawnLines(txEvent),
+    prepareWithdrawnLines(txEvent),
     await prepareRequestsFinalizationLines(txEvent),
     prepareSharesBurntLines(txEvent),
   ];
@@ -550,9 +550,7 @@ function prepareValidatorsCountLines(txEvent: TransactionEvent): string {
   } newly appeared)`;
 }
 
-async function prepareWithdrawnLines(
-  txEvent: TransactionEvent
-): Promise<string> {
+function prepareWithdrawnLines(txEvent: TransactionEvent): string {
   const [ethDistributedEvent] = txEvent.filterLog(
     LIDO_ETHDESTRIBUTED_EVENT,
     LIDO_ADDRESS

--- a/ethereum-operations/src/subagents/lido-report/agent-lido-report.ts
+++ b/ethereum-operations/src/subagents/lido-report/agent-lido-report.ts
@@ -182,7 +182,7 @@ async function handleELRewardsVaultOverfill(
           name: `⚠️ ELRewardsVault overfilled: balance is more than ${OVERFILL_THRESHOLD_PERCENT}% of TVL`,
           description: `Balance: ${balance
             .div(ETH_DECIMALS)
-            .toFixed(3)} ETH\nTVL: ${tvl.div(ETH_DECIMALS).toFixed(3)} ETH`,
+            .toFixed(2)} ETH\nTVL: ${tvl.div(ETH_DECIMALS).toFixed(2)} ETH`,
           alertId: "LIDO-EL-REWARDS-VAULT-OVERFILLED",
           severity: FindingSeverity.Medium,
           type: FindingType.Info,
@@ -217,7 +217,7 @@ async function handleWithdrawalsVaultOverfill(
           name: `⚠️ WithdrawalsVault overfilled: balance is more than ${OVERFILL_THRESHOLD_PERCENT}% of TVL`,
           description: `Balance: ${balance
             .div(ETH_DECIMALS)
-            .toFixed(3)} ETH\nTVL: ${tvl.div(ETH_DECIMALS).toFixed(3)} ETH`,
+            .toFixed(2)} ETH\nTVL: ${tvl.div(ETH_DECIMALS).toFixed(2)} ETH`,
           alertId: "LIDO-WITHDRAWALS-VAULT-OVERFILLED",
           severity: FindingSeverity.Medium,
           type: FindingType.Info,
@@ -255,9 +255,9 @@ async function handleBurnerUnburntSharesOverfill(
           name: `⚠️ Burner overfilled: unburnt shares are more than ${OVERFILL_THRESHOLD_PERCENT}% of total shares`,
           description: `Unburnt: ${unburntShares
             .div(ETH_DECIMALS)
-            .toFixed(3)} 1e18\nTotal shares: ${totalShares
+            .toFixed(2)} 1e18\nTotal shares: ${totalShares
             .div(ETH_DECIMALS)
-            .toFixed(3)} 1e18`,
+            .toFixed(2)} 1e18`,
           alertId: "LIDO-BURNER-UNBURNT-OVERFILLED",
           severity: FindingSeverity.Medium,
           type: FindingType.Info,
@@ -415,15 +415,15 @@ function prepareAPRLines(
 
   const additionalDescription = `Total shares: ${preTotalShares
     .div(ETH_DECIMALS)
-    .toFixed(3)} -> ${postTotalShares
+    .toFixed(2)} -> ${postTotalShares
     .div(ETH_DECIMALS)
     .toFixed(
       3
     )} 1e18 (${strSharesDiffPercent}%)\nTotal pooled ether: ${preTotalEther
     .div(ETH_DECIMALS)
-    .toFixed(3)} -> ${postTotalEther
+    .toFixed(2)} -> ${postTotalEther
     .div(ETH_DECIMALS)
-    .toFixed(3)} ETH (${strEtherDiffPercent}%)\nTime elapsed: ${formatDelay(
+    .toFixed(2)} ETH (${strEtherDiffPercent}%)\nTime elapsed: ${formatDelay(
     Number(timeElapsed)
   )}`;
 
@@ -484,16 +484,16 @@ function prepareRewardsLines(
   const totalRewardsDiff = clRewardsDiff.plus(elRewardsDiff);
   const strCLRewardsDiff =
     Number(clRewardsDiff) > 0
-      ? `+${clRewardsDiff.toFixed(3)}`
-      : clRewardsDiff.toFixed(3);
+      ? `+${clRewardsDiff.toFixed(2)}`
+      : clRewardsDiff.toFixed(2);
   const strELRewardsDiff =
     Number(elRewardsDiff) > 0
-      ? `+${elRewardsDiff.toFixed(3)}`
-      : elRewardsDiff.toFixed(3);
+      ? `+${elRewardsDiff.toFixed(2)}`
+      : elRewardsDiff.toFixed(2);
   const strTotalRewardsDiff =
     Number(totalRewardsDiff) > 0
-      ? `+${totalRewardsDiff.toFixed(3)}`
-      : totalRewardsDiff.toFixed(3);
+      ? `+${totalRewardsDiff.toFixed(2)}`
+      : totalRewardsDiff.toFixed(2);
 
   let strCLRewards = `CL rewards: ${clRewards.toFixed(
     3
@@ -509,8 +509,8 @@ function prepareRewardsLines(
     -LIDO_REPORT_CL_REWARDS_DIFF_PERCENT_THRESHOLD_MEDIUM
   ) {
     strCLRewards =
-      `️CL rewards: ${clRewards.toFixed(3)} ETH 🚨️ decreased ` +
-      `by ${clRewardsDiff.toFixed(3)} ETH (${strCLRewardsDiffPercent}%)`;
+      `️CL rewards: ${clRewards.toFixed(2)} ETH 🚨️ decreased ` +
+      `by ${clRewardsDiff.toFixed(2)} ETH (${strCLRewardsDiffPercent}%)`;
     const severity =
       Number(clRewardsDiffPercent) <
       -LIDO_REPORT_CL_REWARDS_DIFF_PERCENT_THRESHOLD_HIGH
@@ -522,8 +522,8 @@ function prepareRewardsLines(
         description:
           `Rewards decreased from ${lastCLrewards.toFixed(
             3
-          )} ETH to ${clRewards.toFixed(3)} ` +
-          `by ${clRewardsDiff.toFixed(3)} ETH (${strCLRewardsDiffPercent}%)`,
+          )} ETH to ${clRewards.toFixed(2)} ` +
+          `by ${clRewardsDiff.toFixed(2)} ETH (${strCLRewardsDiffPercent}%)`,
         alertId: "LIDO-REPORT-CL-REWARDS-DECREASED",
         severity: severity,
         type: FindingType.Degraded,
@@ -538,7 +538,7 @@ function prepareRewardsLines(
     3
   )} (${strELRewardsDiff}) ETH\nTotal: ${clRewards
     .plus(elRewards)
-    .toFixed(3)} (${strTotalRewardsDiff}) ETH`;
+    .toFixed(2)} (${strTotalRewardsDiff}) ETH`;
 }
 
 function prepareValidatorsCountLines(txEvent: TransactionEvent): string {
@@ -589,15 +589,15 @@ async function prepareWithdrawnLines(
 
   return `*Withdrawn from*\nWithdrawal Vault: ${wdWithdrawn.toFixed(
     3
-  )} ETH\nEL Vault: ${elWithdrawn.div(ETH_DECIMALS).toFixed(3)} ETH${
+  )} ETH\nEL Vault: ${elWithdrawn.div(ETH_DECIMALS).toFixed(2)} ETH${
     elWithdrawnReceivedDiff.gt(0)
       ? ` ⚠️ ${elWithdrawnReceivedDiff
           .div(ETH_DECIMALS)
-          .toFixed(3)} ETH left on the vault`
+          .toFixed(2)} ETH left on the vault`
       : ""
   }\nBuffer: ${
     bufferDiff.lt(0)
-      ? bufferDiff.times(-1).div(ETH_DECIMALS).toFixed(3)
+      ? bufferDiff.times(-1).div(ETH_DECIMALS).toFixed(2)
       : "0.000"
   } ETH`;
 }
@@ -625,7 +625,7 @@ function prepareRequestsFinalizationLines(txEvent: TransactionEvent): string {
   if (requests > 0) {
     description = `Finalized: ${
       Number(to) - Number(from)
-    }\nEther: ${ether.toFixed(3)} ETH\nShare rate: ${shareRate.toFixed(5)}`;
+    }\nEther: ${ether.toFixed(2)} ETH\nShare rate: ${shareRate.toFixed(5)}`;
   }
   return `*Requests finalization*\n${description}`;
 }
@@ -643,7 +643,7 @@ function prepareSharesBurntLines(txEvent: TransactionEvent): string {
         ETH_DECIMALS
       )
     : new BigNumber(0);
-  return `*Shares*\nBurnt: ${sharesBurnt.toFixed(3)} 1e18`;
+  return `*Shares*\nBurnt: ${sharesBurnt.toFixed(2)} 1e18`;
 }
 
 async function getSummaryDigest(block: number) {


### PR DESCRIPTION
```
*APR stats*
APR: 5.26%
Total shares: 5646066.68 -> 5644434.78 1e18 (-0.03%)
Total pooled ether: 6349026.64 -> 6348106.24 ETH (-0.01%)
Time elapsed: 24 hrs 0 sec

*Rewards*
CL rewards: 623.37 (+0.25) ETH
EL rewards: 392.92 (+51.69) ETH
Total: 1016.29 (+51.94) ETH

*Validators*
Count: 196087 (0 newly appeared)

*Withdrawn from vaults*
Withdrawal Vault: 756.29 ETH
EL Vault: 392.92 ETH

*Requests finalization*
Finalized: 41
Ether: 1936.70 ETH
Share rate: 1.12467
Buffered ether used for withdrawal finalization: 787.49 ETH

*Shares*
Burnt: 1722.27 1e18
```