### PR TITLE
chore: Yet another digest polish

### DIFF
--- a/ethereum-operations/e2e/__snapshots__/agent-lido-report.e2e-spec.ts.snap
+++ b/ethereum-operations/e2e/__snapshots__/agent-lido-report.e2e-spec.ts.snap
@@ -6,8 +6,8 @@ Finding {
   "alertId": "LIDO-REPORT-REBASE-DIGEST",
   "description": "*APR stats*
 APR: 5.26%
-Total shares: 5646066.68 -> 5644434.78 × 1e18 (-0.03%)
-Total pooled ether: 6349026.64 -> 6348106.24 ETH (-0.01%)
+Total shares: 5644434.78 (-1631.90) × 1e18
+Total pooled ether: 6348106.24 (-920.40) ETH
 Time elapsed: 24 hrs 0 sec
 
 *Rewards*
@@ -26,7 +26,7 @@ EL Vault: 392.92 ETH
 Finalized: 41
 Ether: 1936.70 ETH
 Share rate: 1.12467
-Buffered ether used for withdrawal finalization: 787.49 ETH
+Used buffer: 787.49 ETH
 
 *Shares*
 Burnt: 1722.27 × 1e18",

--- a/ethereum-operations/src/subagents/lido-report/agent-lido-report.ts
+++ b/ethereum-operations/src/subagents/lido-report/agent-lido-report.ts
@@ -363,23 +363,15 @@ function prepareAPRLines(
     String(tokenRebasedEvent.args.postTotalEther)
   );
 
-  const sharesDiffPercent = postTotalShares
+  const sharesDiffStr = postTotalShares
     .minus(preTotalShares)
-    .div(preTotalShares)
-    .times(100);
-  const strSharesDiffPercent =
-    Number(sharesDiffPercent) > 0
-      ? `+${sharesDiffPercent.toFixed(2)}`
-      : sharesDiffPercent.toFixed(2);
+    .div(ETH_DECIMALS)
+    .toFixed(2);
 
-  const etherDiffPercent = postTotalEther
+  const etherDiffStr = postTotalEther
     .minus(preTotalEther)
-    .div(preTotalEther)
-    .times(100);
-  const strEtherDiffPercent =
-    Number(etherDiffPercent) > 0
-      ? `+${etherDiffPercent.toFixed(2)}`
-      : etherDiffPercent.toFixed(2);
+    .div(ETH_DECIMALS)
+    .toFixed(2);
 
   const apr = calculateAPR(
     timeElapsed,
@@ -412,19 +404,12 @@ function prepareAPRLines(
     findingSeverity = FindingSeverity.High;
   }
 
-  const additionalDescription = `Total shares: ${preTotalShares
-    .div(ETH_DECIMALS)
-    .toFixed(2)} -> ${postTotalShares
-    .div(ETH_DECIMALS)
-    .toFixed(
-      2
-    )} × 1e18 (${strSharesDiffPercent}%)\nTotal pooled ether: ${preTotalEther
-    .div(ETH_DECIMALS)
-    .toFixed(2)} -> ${postTotalEther
-    .div(ETH_DECIMALS)
-    .toFixed(2)} ETH (${strEtherDiffPercent}%)\nTime elapsed: ${formatDelay(
-    Number(timeElapsed)
-  )}`;
+  const additionalDescription =
+    `Total shares: ` +
+    `${postTotalShares.div(ETH_DECIMALS).toFixed(2)} (${sharesDiffStr}) × 1e18` +
+    `\nTotal pooled ether: ` +
+    `${postTotalEther.div(ETH_DECIMALS).toFixed(2)} (${etherDiffStr}) ETH` +
+    `\nTime elapsed: ${formatDelay(Number(timeElapsed))}`;
 
   if (findingName != "") {
     findings.push(
@@ -624,10 +609,10 @@ async function prepareRequestsFinalizationLines(
 
   if (requests > 0) {
     description =
-      `Finalized: ${Number(to) - Number(from)}\nEther: ${ether.toFixed(
-        2
-      )} ETH\nShare rate: ${shareRate.toFixed(5)}` +
-      `\nBuffered ether used for withdrawal finalization: ${
+      `Finalized: ` +
+      `${Number(to) - Number(from)}\nEther: ${ether.toFixed(2)} ETH` +
+      `\nShare rate: ${shareRate.toFixed(5)}` +
+      `\nUsed buffer: ${
         bufferDiff.lt(0)
           ? bufferDiff.times(-1).div(ETH_DECIMALS).toFixed(2)
           : "0.00"

--- a/ethereum-operations/src/subagents/lido-report/agent-lido-report.ts
+++ b/ethereum-operations/src/subagents/lido-report/agent-lido-report.ts
@@ -406,7 +406,9 @@ function prepareAPRLines(
 
   const additionalDescription =
     `Total shares: ` +
-    `${postTotalShares.div(ETH_DECIMALS).toFixed(2)} (${sharesDiffStr}) × 1e18` +
+    `${postTotalShares
+      .div(ETH_DECIMALS)
+      .toFixed(2)} (${sharesDiffStr}) × 1e18` +
     `\nTotal pooled ether: ` +
     `${postTotalEther.div(ETH_DECIMALS).toFixed(2)} (${etherDiffStr}) ETH` +
     `\nTime elapsed: ${formatDelay(Number(timeElapsed))}`;


### PR DESCRIPTION
**APR stats**
APR: 5.49%
Total shares: 5685330.71 (-302.45) × 1e18
Total pooled ether: 6395062.47 (621.79) ETH
Time elapsed: 24 hrs 0 sec

**Rewards**
CL rewards: 624.64 (+1.27) ETH
EL rewards: 444.15 (+51.24) ETH
Total: 1068.80 (+52.51) ETH

**Validators**
Count: 196493 (406 newly appeared)

**Withdrawn from vaults**
Withdrawal Vault: 957.05 ETH
EL Vault: 444.15 ETH

**Requests finalization**
Finalized: 56
Ether: 447.01 ETH
Share rate: 1.12484
Used buffer: 0.00 ETH

**Shares**
Burnt: 397.47 × 1e18