### PR TITLE
chore: fix path for forta.config.json in Readme file

### DIFF
--- a/arbitrum/README.md
+++ b/arbitrum/README.md
@@ -10,7 +10,7 @@
 
 ## Development
 
-Edit `~/.forta/forta.config.json` and set `jsonRpcUrl` to your JSON-RPC provider. Install deps:
+Edit `alerting-forta/<SUBMODULE>/forta.config.json` and set `jsonRpcUrl` to your JSON-RPC provider. Install deps:
 
 ```
 yarn install

--- a/ethereum-governance/README.md
+++ b/ethereum-governance/README.md
@@ -62,7 +62,7 @@ yarn install
 
 ### Mainnet
 
-Edit `~/forta.config.json` and set `jsonRpcUrl` to your Mainnet JSON-RPC provider.
+Edit `alerting-forta/<SUBMODULE>/forta.config.json` and set `jsonRpcUrl` to your Mainnet JSON-RPC provider.
 
 Running in a live mode:
 
@@ -107,7 +107,7 @@ For example, you need to add `testnet` tier support for some new sub-agent:
    } = requireWithTier<typeof Constants>(module, "./constants");
    ```
 2. Copy `./constants.ts` file to `./constants.testnet.ts` and change the addresses and other vars to the testnet ones.
-3. Edit `~/forta.config.json` and set `jsonRpcUrl` to your Testnet JSON-RPC provider.
+3. Edit `alerting-forta/<SUBMODULE>/forta.config.json` and set `jsonRpcUrl` to your Testnet JSON-RPC provider.
 4. Run `export FORTA_AGENT_RUN_TIER=testnet && yarn start:dev`
 
 That's it! Only sub-agents that have `testnet` tier support will be run.

--- a/ethereum-huge-tx/README.md
+++ b/ethereum-huge-tx/README.md
@@ -12,7 +12,7 @@
 
 ## Development
 
-Edit `~/.forta/forta.config.json` and set `jsonRpcUrl` to your JSON-RPC provider. Install deps:
+Edit `alerting-forta/<SUBMODULE>/forta.config.json` and set `jsonRpcUrl` to your JSON-RPC provider. Install deps:
 
 ```
 yarn install

--- a/ethereum-steth/README.md
+++ b/ethereum-steth/README.md
@@ -72,7 +72,7 @@ yarn install
 
 ### Mainnet
 
-Edit `~/forta.config.json` and set `jsonRpcUrl` to your Mainnet JSON-RPC provider.
+Edit `alerting-forta/<SUBMODULE>/forta.config.json` and set `jsonRpcUrl` to your Mainnet JSON-RPC provider.
 
 Running in a live mode:
 
@@ -117,7 +117,7 @@ For example, you need to add `testnet` tier support for some new sub-agent:
    } = requireWithTier<typeof Constants>(module, "./constants");
    ```
 2. Copy `./constants.ts` file to `./constants.testnet.ts` and change the addresses and other vars to the testnet ones.
-3. Edit `~/forta.config.json` and set `jsonRpcUrl` to your Testnet JSON-RPC provider.
+3. Edit `alerting-forta/<SUBMODULE>/forta.config.json` and set `jsonRpcUrl` to your Testnet JSON-RPC provider.
 4. Run `export FORTA_AGENT_RUN_TIER=testnet && yarn start:dev`
 
 That's it! Only sub-agents that have `testnet` tier support will be run.

--- a/ethereum-validators-set/README.md
+++ b/ethereum-validators-set/README.md
@@ -144,7 +144,7 @@ For example, you need to add `testnet` tier support for some new sub-agent:
    } = requireWithTier<typeof Constants>(module, "./constants");
    ```
 2. Copy `./constants.ts` file to `./constants.testnet.ts` and change the addresses and other vars to the testnet ones.
-3. Edit `~/forta.config.json` and set `jsonRpcUrl` to your Testnet JSON-RPC provider.
+3. Edit `alerting-forta/<SUBMODULE>/forta.config.json` and set `jsonRpcUrl` to your Testnet JSON-RPC provider.
 4. Run `export FORTA_AGENT_RUN_TIER=testnet && yarn start:dev`
 
 That's it! Only sub-agents that have `testnet` tier support will be run.

--- a/ethereum-validators-set/README.md
+++ b/ethereum-validators-set/README.md
@@ -99,7 +99,7 @@ yarn install
 
 ### Mainnet
 
-Edit `~/forta.config.json` and set `jsonRpcUrl` to your Mainnet JSON-RPC provider.
+Edit `alerting-forta/<SUBMODULE>/forta.config.json` and set `jsonRpcUrl` to your Mainnet JSON-RPC provider.
 
 Running in a live mode:
 

--- a/l2-bridge-arbitrum/README.md
+++ b/l2-bridge-arbitrum/README.md
@@ -42,7 +42,7 @@ Alert on huge withdrawals
 
 ## Development
 
-Edit `~/.forta/forta.config.json` and set `jsonRpcUrl` to your JSON-RPC provider. Install deps:
+Edit `alerting-forta/<SUBMODULE>/forta.config.json` and set `jsonRpcUrl` to your JSON-RPC provider. Install deps:
 
 ```
 yarn install

--- a/l2-bridge-balance/README.md
+++ b/l2-bridge-balance/README.md
@@ -16,7 +16,7 @@ Alerts about balance mismatch
 
 ## Development
 
-Edit `~/.forta/forta.config.json` and set `jsonRpcUrl` to your JSON-RPC provider. Install deps:
+Edit `alerting-forta/<SUBMODULE>/forta.config.json` and set `jsonRpcUrl` to your JSON-RPC provider. Install deps:
 
 ```
 yarn install

--- a/l2-bridge-ethereum/README.md
+++ b/l2-bridge-ethereum/README.md
@@ -26,7 +26,7 @@ Alert on proxy state changes
 
 ## Development
 
-Edit `~/.forta/forta.config.json` and set `jsonRpcUrl` to your JSON-RPC provider. Install deps:
+Edit `alerting-forta/<SUBMODULE>/forta.config.json` and set `jsonRpcUrl` to your JSON-RPC provider. Install deps:
 
 ```
 yarn install

--- a/l2-bridge-optimism/README.md
+++ b/l2-bridge-optimism/README.md
@@ -42,7 +42,7 @@ Alert on huge withdrawals
 
 ## Development
 
-Edit `~/.forta/forta.config.json` and set `jsonRpcUrl` to your JSON-RPC provider. Install deps:
+Edit `alerting-forta/<SUBMODULE>/forta.config.json` and set `jsonRpcUrl` to your JSON-RPC provider. Install deps:
 
 ```
 yarn install

--- a/lido-on-polygon/README.md
+++ b/lido-on-polygon/README.md
@@ -42,7 +42,7 @@ Withdrawals monitoring
 
 ## Development
 
-Edit `~/.forta/forta.config.json` and set `jsonRpcUrl` to your JSON-RPC provider. Install deps:
+Edit `alerting-forta/<SUBMODULE>/forta.config.json` and set `jsonRpcUrl` to your JSON-RPC provider. Install deps:
 
 ```
 yarn install

--- a/multisig-watcher/README.md
+++ b/multisig-watcher/README.md
@@ -10,7 +10,7 @@ Alerts on the major gnosis safe events on all Lido-on-X networks
 
 ## Development
 
-Edit `~/.forta/forta.config.json` and set `jsonRpcUrl` to your JSON-RPC provider. Install deps:
+Edit `alerting-forta/<SUBMODULE>/forta.config.json` and set `jsonRpcUrl` to your JSON-RPC provider. Install deps:
 
 ```
 yarn install

--- a/phishing-detect/README.md
+++ b/phishing-detect/README.md
@@ -21,7 +21,7 @@
 
 ## Development
 
-Edit `~/.forta/forta.config.json` and set `jsonRpcUrl` to your JSON-RPC provider. Install deps:
+Edit `alerting-forta/<SUBMODULE>/forta.config.json` and set `jsonRpcUrl` to your JSON-RPC provider. Install deps:
 
 ```
 yarn install

--- a/polygon/README.md
+++ b/polygon/README.md
@@ -12,7 +12,7 @@
 
 ## Development
 
-Edit `~/.forta/forta.config.json` and set `jsonRpcUrl` to your JSON-RPC provider. Install deps:
+Edit `alerting-forta/<SUBMODULE>/forta.config.json` and set `jsonRpcUrl` to your JSON-RPC provider. Install deps:
 
 ```
 yarn install

--- a/reverted-tx-watcher/README.md
+++ b/reverted-tx-watcher/README.md
@@ -10,7 +10,7 @@
 
 ## Development
 
-Edit `~/.forta/forta.config.json` and set `jsonRpcUrl` to your JSON-RPC provider. Install deps:
+Edit `alerting-forta/<SUBMODULE>/forta.config.json` and set `jsonRpcUrl` to your JSON-RPC provider. Install deps:
 
 ```
 yarn install

--- a/storage-watcher/README.md
+++ b/storage-watcher/README.md
@@ -10,7 +10,7 @@
 
 ## Development
 
-Edit `~/.forta/forta.config.json` and set `jsonRpcUrl` to your JSON-RPC provider. Install deps:
+Edit `alerting-forta/<SUBMODULE>/forta.config.json` and set `jsonRpcUrl` to your JSON-RPC provider. Install deps:
 
 ```
 yarn install

--- a/template/README.md
+++ b/template/README.md
@@ -10,7 +10,7 @@ Describe alerts here
 
 ## Development
 
-Edit `~/.forta/forta.config.json` and set `jsonRpcUrl` to your JSON-RPC provider. Install deps:
+Edit `alerting-forta/<SUBMODULE>/forta.config.json` and set `jsonRpcUrl` to your JSON-RPC provider. Install deps:
 
 ```
 yarn install

--- a/voting-watcher/README.md
+++ b/voting-watcher/README.md
@@ -12,7 +12,7 @@
 
 ## Development
 
-Edit `~/.forta/forta.config.json` and set `jsonRpcUrl` to your JSON-RPC provider. Install deps:
+Edit `alerting-forta/<SUBMODULE>/forta.config.json` and set `jsonRpcUrl` to your JSON-RPC provider. Install deps:
 
 ```
 yarn install


### PR DESCRIPTION
I was a little bit confused for the path `~/...`. Typically, it means a home directory of the current user.